### PR TITLE
feat: Reliers can specify an email and disable cached creds.

### DIFF
--- a/client/FxaRelierClient.js
+++ b/client/FxaRelierClient.js
@@ -69,6 +69,11 @@ define([
        *   URI to redirect to when complete
        *   @param {String} config.scope
        *   OAuth scope
+       *   @param {String} [config.email]
+       *   Email address used to pre-fill into the account form,
+       *   but the user is free to change it. Set to the string literal
+       *   `blank` to ignore any previously signed in email. Default is
+       *   the last email address used to sign in.
        *   @param {String} [config.force_email]
        *   Force the user to sign in with the given email
        *   @param {String} [config.ui]
@@ -98,6 +103,9 @@ define([
        *   URI to redirect to when complete
        *   @param {String} config.scope
        *   OAuth scope
+       *   @param {String} [config.email]
+       *   Email address used to pre-fill into the account form,
+       *   but the user is free to change it.
        *   @param {String} [config.ui]
        *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
        */

--- a/client/auth/api.js
+++ b/client/auth/api.js
@@ -43,6 +43,10 @@ define([
       redirect_uri: config.redirect_uri
     };
 
+    if (config.email) {
+      queryParams.email = config.email;
+    }
+
     if (config.force_email) {
       queryParams.email = config.force_email;
     }
@@ -75,6 +79,11 @@ define([
      *   URI to redirect to when complete
      *   @param {String} config.scope
      *   OAuth scope
+     *   @param {String} [config.email]
+     *   Email address used to pre-fill into the account form,
+     *   but the user is free to change it. Set to the string literal
+     *   `blank` to ignore any previously signed in email. Default is
+     *   the last email address used to sign in.
      *   @param {String} [config.force_email]
      *   Force the user to sign in with the given email
      */
@@ -97,6 +106,9 @@ define([
      *   URI to redirect to when complete
      *   @param {String} config.scope
      *   OAuth scope
+     *   @param {String} [config.email]
+     *   Email address used to pre-fill into the account form,
+     *   but the user is free to change it.
      */
     signUp: function (config) {
       return authenticate.call(this, Constants.SIGNUP_ENDPOINT, config);

--- a/tests/spec/auth/lightbox/api.js
+++ b/tests/spec/auth/lightbox/api.js
@@ -101,13 +101,16 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
         return lightboxAPI.signIn({
           state: 'state',
           scope: 'scope',
-          redirect_uri: 'redirect_uri'
+          redirect_uri: 'redirect_uri',
+          email: 'blank'
         })
         .then(function () {
-          assert.isTrue(/oauth\/signin/.test(lightbox.load.args[0]));
-          assert.isTrue(/state=state/.test(lightbox.load.args[0]));
-          assert.isTrue(/scope=scope/.test(lightbox.load.args[0]));
-          assert.isTrue(/redirect_uri=redirect_uri/.test(lightbox.load.args[0]));
+          var loadUrl = lightbox.load.args[0][0];
+          assert.include(loadUrl, 'oauth/signin');
+          assert.include(loadUrl, 'state=state');
+          assert.include(loadUrl, 'scope=scope');
+          assert.include(loadUrl, 'redirect_uri=redirect_uri');
+          assert.include(loadUrl, 'email=blank');
         });
       });
 
@@ -124,11 +127,12 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
           force_email: 'testuser@testuser.com'
         })
         .then(function () {
-          assert.isTrue(/force_auth/.test(lightbox.load.args[0]));
-          assert.isTrue(/state=state/.test(lightbox.load.args[0]));
-          assert.isTrue(/scope=scope/.test(lightbox.load.args[0]));
-          assert.isTrue(/redirect_uri=redirect_uri/.test(lightbox.load.args[0]));
-          assert.isTrue(/email=testuser%40testuser.com/.test(lightbox.load.args[0]));
+          var loadUrl = lightbox.load.args[0][0];
+          assert.include(loadUrl, 'force_auth');
+          assert.include(loadUrl, 'state=state');
+          assert.include(loadUrl, 'scope=scope');
+          assert.include(loadUrl, 'redirect_uri=redirect_uri');
+          assert.include(loadUrl, 'email=testuser%40testuser.com');
         });
       });
 

--- a/tests/spec/auth/redirect/api.js
+++ b/tests/spec/auth/redirect/api.js
@@ -61,7 +61,8 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
         return redirectAPI.signIn({
           state: 'state',
           scope: 'scope',
-          redirect_uri: 'redirect_uri'
+          redirect_uri: 'redirect_uri',
+          email: 'blank'
         })
         .then(function () {
           var redirectedTo = windowMock.location.href;
@@ -69,6 +70,7 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
           assert.include(redirectedTo, 'state=state');
           assert.include(redirectedTo, 'scope=scope');
           assert.include(redirectedTo, 'redirect_uri=redirect_uri');
+          assert.include(redirectedTo, 'email=blank');
         });
       });
 


### PR DESCRIPTION
A relier can specify an `email` parameter used to pre-fill the email field in the content server. Specifying `email=blank` will disable cached credentials.

fixes #15