### PR TITLE
feat(client): add `auth.forceAuth` to use the /oauth/force_auth endpoint on the content server.

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,5 +1,8 @@
 # fxa-relier-client Relier API
 
+This is a quick start guide to the API. Details about each parameter
+can be viewed at http://mozilla.github.io/fxa-relier-client/index.html.
+
 ## Prerequisites
 1. An OAuth client id is needed. Go get one from the folks in the #fxa IRC channel on irc.mozilla.org.
 2. Download/copy/install a copy of the fxa-relier-client in a location accessible by your site. See [installation](./README.md#installation).
@@ -22,7 +25,21 @@ var fxapi = new FirefoxAPI({
 var promise = fxapi.auth.signIn({
     scope: <scope>,
     redirect_uri: <redirect URI>,
-    state: <state>
+    state: <state>,
+    email: <email>
+});
+```
+
+The promise will not resolve if the user is redirected to Firefox Accounts. This is the expected behavior in the redirect flow since the user is redirected before the promise can resolve. The promise will be rejected if a required parameter is missing.
+
+## Force an existing user to sign in with the specified email address.
+
+```js
+var promise = fxapi.auth.forceAuth({
+    scope: <scope>,
+    redirect_uri: <redirect URI>,
+    state: <state>,
+    email: <email>
 });
 ```
 

--- a/client/FxaRelierClient.js
+++ b/client/FxaRelierClient.js
@@ -69,6 +69,11 @@ define([
        *   URI to redirect to when complete
        *   @param {String} config.scope
        *   OAuth scope
+       *   @param {String} [config.email]
+       *   Email address used to pre-fill into the account form,
+       *   but the user is free to change it. Set to the string literal
+       *   `blank` to ignore any previously signed in email. Default is
+       *   the last email address used to sign in.
        *   @param {String} [config.force_email]
        *   Force the user to sign in with the given email
        *   @param {String} [config.ui]
@@ -98,6 +103,9 @@ define([
        *   URI to redirect to when complete
        *   @param {String} config.scope
        *   OAuth scope
+       *   @param {String} [config.email]
+       *   Email address used to pre-fill into the account form,
+       *   but the user is free to change it.
        *   @param {String} [config.ui]
        *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
        */

--- a/client/FxaRelierClient.js
+++ b/client/FxaRelierClient.js
@@ -59,7 +59,7 @@ define([
 
     this.auth = {
       /**
-       * Sign in an existing user
+       * Sign in an existing user.
        *
        * @method signIn
        * @param {Object} config - configuration
@@ -86,6 +86,37 @@ define([
 
           var api = getUI(self, config.ui, clientId, options);
           return api.signIn(config)
+            .fin(function () {
+              delete self._ui;
+            });
+        });
+      },
+
+      /**
+       * Force a user to sign in as an existing user.
+       *
+       * @method forceAuth
+       * @param {Object} config - configuration
+       *   @param {String} config.state
+       *   CSRF/State token
+       *   @param {String} config.redirect_uri
+       *   URI to redirect to when complete
+       *   @param {String} config.scope
+       *   OAuth scope
+       *   @param {String} config.email
+       *   Email address the user must sign in with. The user
+       *   is unable to modify the email address and is unable
+       *   to sign up if the address is not registered.
+       *   @param {String} [config.ui]
+       *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
+       */
+      forceAuth: function (config) {
+        var self = this;
+        return p().then(function () {
+          config = config || {};
+
+          var api = getUI(self, config.ui, clientId, options);
+          return api.forceAuth(config)
             .fin(function () {
               delete self._ui;
             });

--- a/client/auth/api.js
+++ b/client/auth/api.js
@@ -43,6 +43,10 @@ define([
       redirect_uri: config.redirect_uri
     };
 
+    if (config.email) {
+      queryParams.email = config.email;
+    }
+
     if (config.force_email) {
       queryParams.email = config.force_email;
     }
@@ -75,6 +79,11 @@ define([
      *   URI to redirect to when complete
      *   @param {String} config.scope
      *   OAuth scope
+     *   @param {String} [config.email]
+     *   Email address used to pre-fill into the account form,
+     *   but the user is free to change it. Set to the string literal
+     *   `blank` to ignore any previously signed in email. Default is
+     *   the last email address used to sign in.
      *   @param {String} [config.force_email]
      *   Force the user to sign in with the given email
      */
@@ -97,6 +106,9 @@ define([
      *   URI to redirect to when complete
      *   @param {String} config.scope
      *   OAuth scope
+     *   @param {String} [config.email]
+     *   Email address used to pre-fill into the account form,
+     *   but the user is free to change it.
      */
     signUp: function (config) {
       return authenticate.call(this, Constants.SIGNUP_ENDPOINT, config);

--- a/client/lib/constants.js
+++ b/client/lib/constants.js
@@ -9,7 +9,7 @@ define([], function () {
     DEFAULT_FXA_HOST: 'https://accounts.firefox.com',
     SIGNIN_ENDPOINT: 'oauth/signin',
     SIGNUP_ENDPOINT: 'oauth/signup',
-    FORCE_EMAIL_ENDPOINT: 'force_auth'
+    FORCE_AUTH_ENDPOINT: 'oauth/force_auth'
   };
 });
 

--- a/tests/spec/auth/lightbox/api.js
+++ b/tests/spec/auth/lightbox/api.js
@@ -101,13 +101,16 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
         return lightboxAPI.signIn({
           state: 'state',
           scope: 'scope',
-          redirect_uri: 'redirect_uri'
+          redirect_uri: 'redirect_uri',
+          email: 'blank'
         })
         .then(function () {
-          assert.isTrue(/oauth\/signin/.test(lightbox.load.args[0]));
-          assert.isTrue(/state=state/.test(lightbox.load.args[0]));
-          assert.isTrue(/scope=scope/.test(lightbox.load.args[0]));
-          assert.isTrue(/redirect_uri=redirect_uri/.test(lightbox.load.args[0]));
+          var loadUrl = lightbox.load.args[0][0];
+          assert.include(loadUrl, 'oauth/signin');
+          assert.include(loadUrl, 'state=state');
+          assert.include(loadUrl, 'scope=scope');
+          assert.include(loadUrl, 'redirect_uri=redirect_uri');
+          assert.include(loadUrl, 'email=blank');
         });
       });
 
@@ -124,11 +127,12 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
           force_email: 'testuser@testuser.com'
         })
         .then(function () {
-          assert.isTrue(/force_auth/.test(lightbox.load.args[0]));
-          assert.isTrue(/state=state/.test(lightbox.load.args[0]));
-          assert.isTrue(/scope=scope/.test(lightbox.load.args[0]));
-          assert.isTrue(/redirect_uri=redirect_uri/.test(lightbox.load.args[0]));
-          assert.isTrue(/email=testuser%40testuser.com/.test(lightbox.load.args[0]));
+          var loadUrl = lightbox.load.args[0][0];
+          assert.include(loadUrl, 'force_auth');
+          assert.include(loadUrl, 'state=state');
+          assert.include(loadUrl, 'scope=scope');
+          assert.include(loadUrl, 'redirect_uri=redirect_uri');
+          assert.include(loadUrl, 'email=testuser%40testuser.com');
         });
       });
 

--- a/tests/spec/auth/lightbox/api.js
+++ b/tests/spec/auth/lightbox/api.js
@@ -154,7 +154,7 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
       testCommonMissingOptions('forceAuth');
 
       bdd.it('should reject if `email` is not specified', function () {
-        return testMissingOption('forceAuth', 'state');
+        return testMissingOption('forceAuth', 'email');
       });
 
       bdd.it('should open the lightbox to /oauth/force_auth with the expected query parameters', function () {

--- a/tests/spec/auth/lightbox/api.js
+++ b/tests/spec/auth/lightbox/api.js
@@ -51,7 +51,8 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
       var options = {
         state: 'state',
         scope: 'scope',
-        redirect_uri: 'redirect_uri'
+        redirect_uri: 'redirect_uri',
+        email: 'testuser@testuser.com'
       };
 
       delete options[optionName];
@@ -62,18 +63,22 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
         });
     }
 
-    bdd.describe('signIn', function () {
+    function testCommonMissingOptions(endpoint) {
       bdd.it('should reject if `scope` is not specified', function () {
-        return testMissingOption('signIn', 'scope');
+        return testMissingOption(endpoint, 'scope');
       });
 
       bdd.it('should reject if `redirect_uri` is not specified', function () {
-        return testMissingOption('signIn', 'redirect_uri');
+        return testMissingOption(endpoint, 'redirect_uri');
       });
 
       bdd.it('should reject if `state` is not specified', function () {
-        return testMissingOption('signIn', 'state');
+        return testMissingOption(endpoint, 'state');
       });
+    }
+
+    bdd.describe('signIn', function () {
+      testCommonMissingOptions('signIn');
 
       bdd.it('should reject if a lightbox is already open', function () {
         lightboxAPI.signIn({
@@ -114,28 +119,6 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
         });
       });
 
-      bdd.it('should open the lightbox to the /force_auth page with the expected query parameters if the RP forces authentication as a user', function () {
-        sinon.spy(lightbox, 'load');
-        sinon.stub(channel, 'attach', function () {
-          return p();
-        });
-
-        return lightboxAPI.signIn({
-          state: 'state',
-          scope: 'scope',
-          redirect_uri: 'redirect_uri',
-          force_email: 'testuser@testuser.com'
-        })
-        .then(function () {
-          var loadUrl = lightbox.load.args[0][0];
-          assert.include(loadUrl, 'force_auth');
-          assert.include(loadUrl, 'state=state');
-          assert.include(loadUrl, 'scope=scope');
-          assert.include(loadUrl, 'redirect_uri=redirect_uri');
-          assert.include(loadUrl, 'email=testuser%40testuser.com');
-        });
-      });
-
       bdd.it('should return the result returned by the channel', function () {
         sinon.stub(channel, 'attach', function () {
           return p('oauth_result');
@@ -167,18 +150,39 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
       });
     });
 
+    bdd.describe('forceAuth', function () {
+      testCommonMissingOptions('forceAuth');
+
+      bdd.it('should reject if `email` is not specified', function () {
+        return testMissingOption('forceAuth', 'state');
+      });
+
+      bdd.it('should open the lightbox to /oauth/force_auth with the expected query parameters', function () {
+        sinon.spy(lightbox, 'load');
+        sinon.stub(channel, 'attach', function () {
+          return p();
+        });
+
+        return lightboxAPI.forceAuth({
+          state: 'state',
+          scope: 'scope',
+          redirect_uri: 'redirect_uri',
+          email: 'testuser@testuser.com'
+        })
+        .then(function () {
+          var loadUrl = lightbox.load.args[0][0];
+          assert.include(loadUrl, 'oauth/force_auth');
+          assert.include(loadUrl, 'state=state');
+          assert.include(loadUrl, 'scope=scope');
+          assert.include(loadUrl, 'redirect_uri=redirect_uri');
+          assert.include(loadUrl, 'email=testuser%40testuser.com');
+        });
+      });
+    });
+
+
     bdd.describe('signUp', function () {
-      bdd.it('should reject if `scope` is not specified', function () {
-        return testMissingOption('signUp', 'scope');
-      });
-
-      bdd.it('should reject if `redirect_uri` is not specified', function () {
-        return testMissingOption('signUp', 'redirect_uri');
-      });
-
-      bdd.it('should reject if `state` is not specified', function () {
-        return testMissingOption('signUp', 'state');
-      });
+      testCommonMissingOptions('signUp');
 
       bdd.it('should reject if a lightbox is already open', function () {
         lightboxAPI.signUp({

--- a/tests/spec/auth/redirect/api.js
+++ b/tests/spec/auth/redirect/api.js
@@ -61,7 +61,8 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
         return redirectAPI.signIn({
           state: 'state',
           scope: 'scope',
-          redirect_uri: 'redirect_uri'
+          redirect_uri: 'redirect_uri',
+          email: 'blank'
         })
         .then(function () {
           var redirectedTo = windowMock.location.href;
@@ -69,6 +70,7 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
           assert.include(redirectedTo, 'state=state');
           assert.include(redirectedTo, 'scope=scope');
           assert.include(redirectedTo, 'redirect_uri=redirect_uri');
+          assert.include(redirectedTo, 'email=blank');
         });
       });
 

--- a/tests/spec/auth/redirect/api.js
+++ b/tests/spec/auth/redirect/api.js
@@ -91,7 +91,7 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
       });
 
       bdd.it('should reject if `email` is not specified', function () {
-        return testMissingOption('forceAuth', 'state');
+        return testMissingOption('forceAuth', 'email');
       });
 
       bdd.it('should redirect to /oauth/force_auth with the expected query parameters', function () {

--- a/tests/spec/auth/redirect/api.js
+++ b/tests/spec/auth/redirect/api.js
@@ -33,7 +33,8 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
       var options = {
         state: 'state',
         scope: 'scope',
-        redirect_uri: 'redirect_uri'
+        redirect_uri: 'redirect_uri',
+        email: 'testuser@testuser.com'
       };
 
       delete options[optionName];
@@ -74,16 +75,35 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
         });
       });
 
-      bdd.it('should redirect to the /force_auth page with the expected query parameters if the RP forces authentication as a user', function () {
-        return redirectAPI.signIn({
+    });
+
+    bdd.describe('forceAuth', function () {
+      bdd.it('should reject if `scope` is not specified', function () {
+        return testMissingOption('forceAuth', 'scope');
+      });
+
+      bdd.it('should reject if `redirect_uri` is not specified', function () {
+        return testMissingOption('forceAuth', 'redirect_uri');
+      });
+
+      bdd.it('should reject if `state` is not specified', function () {
+        return testMissingOption('forceAuth', 'state');
+      });
+
+      bdd.it('should reject if `email` is not specified', function () {
+        return testMissingOption('forceAuth', 'state');
+      });
+
+      bdd.it('should redirect to /oauth/force_auth with the expected query parameters', function () {
+        return redirectAPI.forceAuth({
           state: 'state',
           scope: 'scope',
           redirect_uri: 'redirect_uri',
-          force_email: 'testuser@testuser.com'
+          email: 'testuser@testuser.com'
         })
         .then(function () {
           var redirectedTo = windowMock.location.href;
-          assert.include(redirectedTo, '/force_auth');
+          assert.include(redirectedTo, '/oauth/force_auth');
           assert.include(redirectedTo, 'state=state');
           assert.include(redirectedTo, 'scope=scope');
           assert.include(redirectedTo, 'redirect_uri=redirect_uri');


### PR DESCRIPTION
Remove the `force_email` parameter to signIn. This now mirrors how the OAuth and Content servers work.

Includes #17 
Fixes #18 