### PR TITLE
fix(client): Redirect to the oauth server instead of the content server.

### DIFF
--- a/client/FxaRelierClient.js
+++ b/client/FxaRelierClient.js
@@ -43,8 +43,10 @@ define([
    * @constructor
    * @param {string} clientId - the OAuth client ID for the relier
    * @param {Object} [options={}] - configuration
-   *   @param {String} [options.fxaHost]
+   *   @param {String} [options.contentHost]
    *   Firefox Accounts Content Server host
+   *   @param {String} [options.oauthHost]
+   *   Firefox Accounts OAuth Server host
    *   @param {Object} [options.window]
    *   window override, used for unit tests
    *   @param {Object} [options.lightbox]

--- a/client/auth/api.js
+++ b/client/auth/api.js
@@ -36,21 +36,22 @@ define([
     this._window = options.window || window;
   }
 
-  function authenticate(page, config) {
+  function authenticate(action, config) {
     //jshint validthis: true
     var self = this;
     return p().then(function () {
       var requiredOptions = ['scope', 'state', 'redirect_uri'];
       Options.checkRequired(requiredOptions, config);
 
-      var fxaUrl = getFxaUrl.call(self, page, config);
+      var fxaUrl = getFxaUrl.call(self, action, config);
       return self.openFxa(fxaUrl);
     });
   }
 
-  function getFxaUrl(page, config) {
+  function getFxaUrl(action, config) {
     //jshint validthis: true
     var queryParams = {
+      action: action,
       client_id: this._clientId,
       state: config.state,
       scope: config.scope,
@@ -61,7 +62,7 @@ define([
       queryParams.email = config.email;
     }
 
-    return this._fxaHost + '/' + page + Url.objectToQueryString(queryParams);
+    return this._fxaHost + Url.objectToQueryString(queryParams);
   }
 
   AuthenticationAPI.prototype = {
@@ -97,7 +98,7 @@ define([
      */
     signIn: function (config) {
       config = config || {};
-      return authenticate.call(this, Constants.SIGNIN_ENDPOINT, config);
+      return authenticate.call(this, Constants.SIGNIN_ACTION, config);
     },
 
     /**
@@ -125,7 +126,7 @@ define([
         var requiredOptions = ['email'];
         Options.checkRequired(requiredOptions, config);
 
-        return authenticate.call(self, Constants.FORCE_AUTH_ENDPOINT, config);
+        return authenticate.call(self, Constants.FORCE_AUTH_ACTION, config);
       });
     },
 
@@ -145,7 +146,7 @@ define([
      *   but the user is free to change it.
      */
     signUp: function (config) {
-      return authenticate.call(this, Constants.SIGNUP_ENDPOINT, config);
+      return authenticate.call(this, Constants.SIGNUP_ACTION, config);
     },
   };
 

--- a/client/auth/api.js
+++ b/client/auth/api.js
@@ -17,8 +17,10 @@ define([
    * @constructor
    * @param {string} clientId - the OAuth client ID for the relier
    * @param {Object} [options={}] - configuration
-   *   @param {String} [options.fxaHost]
+   *   @param {String} [options.contentHost]
    *   Firefox Accounts Content Server host
+   *   @param {String} [options.oauthHost]
+   *   Firefox Accounts OAuth Server host
    *   @param {Object} [options.window]
    *   window override, used for unit tests
    *   @param {Object} [options.lightbox]
@@ -32,7 +34,8 @@ define([
     }
 
     this._clientId = clientId;
-    this._fxaHost = options.fxaHost || Constants.DEFAULT_FXA_HOST;
+    this._contentHost = options.contentHost || Constants.DEFAULT_CONTENT_HOST;
+    this._oauthHost = options.oauthHost || Constants.DEFAULT_OAUTH_HOST;
     this._window = options.window || window;
   }
 
@@ -62,7 +65,7 @@ define([
       queryParams.email = config.email;
     }
 
-    return this._fxaHost + Url.objectToQueryString(queryParams);
+    return this._oauthHost + Url.objectToQueryString(queryParams);
   }
 
   AuthenticationAPI.prototype = {

--- a/client/auth/lightbox/api.js
+++ b/client/auth/lightbox/api.js
@@ -52,7 +52,7 @@ define([
     }
 
     self._channel = new IFrameChannel({
-      iframeHost: self._fxaHost,
+      iframeHost: self._contentHost,
       contentWindow: lightbox.getContentWindow(),
       window: self._window
     });

--- a/client/lib/constants.js
+++ b/client/lib/constants.js
@@ -6,7 +6,8 @@ define([], function () {
   'use strict';
 
   return {
-    DEFAULT_FXA_HOST: 'https://oauth.accounts.firefox.com/v1/authorization',
+    DEFAULT_CONTENT_HOST: 'https://accounts.firefox.com',
+    DEFAULT_OAUTH_HOST: 'https://oauth.accounts.firefox.com/v1/authorization',
     SIGNIN_ACTION: 'signin',
     SIGNUP_ACTION: 'signup',
     FORCE_AUTH_ACTION: 'force_auth'

--- a/client/lib/constants.js
+++ b/client/lib/constants.js
@@ -6,10 +6,10 @@ define([], function () {
   'use strict';
 
   return {
-    DEFAULT_FXA_HOST: 'https://accounts.firefox.com',
-    SIGNIN_ENDPOINT: 'oauth/signin',
-    SIGNUP_ENDPOINT: 'oauth/signup',
-    FORCE_AUTH_ENDPOINT: 'oauth/force_auth'
+    DEFAULT_FXA_HOST: 'https://oauth.accounts.firefox.com/v1/authorization',
+    SIGNIN_ACTION: 'signin',
+    SIGNUP_ACTION: 'signup',
+    FORCE_AUTH_ACTION: 'force_auth'
   };
 });
 

--- a/tests/spec/auth/lightbox/api.js
+++ b/tests/spec/auth/lightbox/api.js
@@ -111,7 +111,7 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
         })
         .then(function () {
           var loadUrl = lightbox.load.args[0][0];
-          assert.include(loadUrl, 'oauth/signin');
+          assert.include(loadUrl, 'action=signin');
           assert.include(loadUrl, 'state=state');
           assert.include(loadUrl, 'scope=scope');
           assert.include(loadUrl, 'redirect_uri=redirect_uri');
@@ -157,7 +157,7 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
         return testMissingOption('forceAuth', 'email');
       });
 
-      bdd.it('should open the lightbox to /oauth/force_auth with the expected query parameters', function () {
+      bdd.it('should open the lightbox to with action=force_auth with the expected query parameters', function () {
         sinon.spy(lightbox, 'load');
         sinon.stub(channel, 'attach', function () {
           return p();
@@ -171,7 +171,7 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
         })
         .then(function () {
           var loadUrl = lightbox.load.args[0][0];
-          assert.include(loadUrl, 'oauth/force_auth');
+          assert.include(loadUrl, 'action=force_auth');
           assert.include(loadUrl, 'state=state');
           assert.include(loadUrl, 'scope=scope');
           assert.include(loadUrl, 'redirect_uri=redirect_uri');
@@ -213,7 +213,7 @@ function (bdd, assert, LightboxAPI, Lightbox, IframeChannel,
           redirect_uri: 'redirect_uri'
         })
         .then(function () {
-          assert.isTrue(/oauth\/signup/.test(lightbox.load.args[0]));
+          assert.isTrue(/action=signup/.test(lightbox.load.args[0]));
           assert.isTrue(/state=state/.test(lightbox.load.args[0]));
           assert.isTrue(/scope=scope/.test(lightbox.load.args[0]));
           assert.isTrue(/redirect_uri=redirect_uri/.test(lightbox.load.args[0]));

--- a/tests/spec/auth/redirect/api.js
+++ b/tests/spec/auth/redirect/api.js
@@ -58,7 +58,7 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
         return testMissingOption('signIn', 'state');
       });
 
-      bdd.it('should redirect to the /signin page with the expected query parameters', function () {
+      bdd.it('should redirect with action=signin page and other expected query parameters', function () {
         return redirectAPI.signIn({
           state: 'state',
           scope: 'scope',
@@ -67,7 +67,7 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
         })
         .then(function () {
           var redirectedTo = windowMock.location.href;
-          assert.include(redirectedTo, '/signin');
+          assert.include(redirectedTo, 'action=signin');
           assert.include(redirectedTo, 'state=state');
           assert.include(redirectedTo, 'scope=scope');
           assert.include(redirectedTo, 'redirect_uri=redirect_uri');
@@ -94,7 +94,7 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
         return testMissingOption('forceAuth', 'email');
       });
 
-      bdd.it('should redirect to /oauth/force_auth with the expected query parameters', function () {
+      bdd.it('should redirect with action=force_auth and other expected query parameters', function () {
         return redirectAPI.forceAuth({
           state: 'state',
           scope: 'scope',
@@ -103,7 +103,7 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
         })
         .then(function () {
           var redirectedTo = windowMock.location.href;
-          assert.include(redirectedTo, '/oauth/force_auth');
+          assert.include(redirectedTo, 'action=force_auth');
           assert.include(redirectedTo, 'state=state');
           assert.include(redirectedTo, 'scope=scope');
           assert.include(redirectedTo, 'redirect_uri=redirect_uri');
@@ -125,7 +125,7 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
         return testMissingOption('signUp', 'state');
       });
 
-      bdd.it('should redirect to the /signup page with the expected query parameters', function () {
+      bdd.it('should redirect with action=signup and other expected query parameters', function () {
         return redirectAPI.signUp({
           state: 'state',
           scope: 'scope',
@@ -133,7 +133,7 @@ function (bdd, assert, RedirectAPI, WindowMock, sinon, p) {
         })
         .then(function () {
           var redirectedTo = windowMock.location.href;
-          assert.include(redirectedTo, '/signup');
+          assert.include(redirectedTo, 'action=signup');
           assert.include(redirectedTo, 'state=state');
           assert.include(redirectedTo, 'scope=scope');
           assert.include(redirectedTo, 'redirect_uri=redirect_uri');


### PR DESCRIPTION
The OAuth API contract specifies the user is first redirected to the OAuth server, then to the Content server. Honor this contract.

fixes #13