### PR TITLE
feat: Add the .token and .profile namespaces.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "tests"
   ],
   "dependencies": {
-    "p-promise": "https://github.com/rkatic/p.git#3c1fe61c9ba47aa3c09a55eb3025bd29a238d1ea"
+    "p-promise": "https://github.com/rkatic/p.git#3c1fe61c9ba47aa3c09a55eb3025bd29a238d1ea",
+    "micrajax": "0.0.5"
   },
   "devDependencies": {
     "almond": "0.3.0",

--- a/client/FxaRelierClient.js
+++ b/client/FxaRelierClient.js
@@ -3,40 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  'p-promise',
-  'client/auth/lightbox/api',
-  'client/auth/redirect/api'
-], function (p, LightboxUI, RedirectUI) {
+  'client/auth/api',
+  'client/token/api',
+  'client/profile/api'
+], function (AuthAPI, TokenAPI, ProfileAPI) {
   'use strict';
-
-  var UIs = {
-    'default': RedirectUI,
-    lightbox: LightboxUI,
-    redirect: RedirectUI
-  };
-
-  function getUI(context, ui, clientId, options) {
-    if (context._ui) {
-      throw new Error('Firefox Accounts is already open');
-    }
-
-    if (typeof ui === 'object') {
-      // allow a UI to be passed in for testing.
-      context._ui = ui;
-    } else {
-      ui = ui || 'default';
-      var UI = UIs[ui];
-
-      if (! UI) {
-        throw new Error('Invalid ui: ' + ui);
-      }
-
-      context._ui = new UI(clientId, options);
-    }
-
-    return context._ui;
-  }
-
 
   /**
    * @class FxaRelierClient
@@ -47,6 +18,8 @@ define([
    *   Firefox Accounts Content Server host
    *   @param {String} [options.oauthHost]
    *   Firefox Accounts OAuth Server host
+   *   @param {String} [options.profileHost]
+   *   Firefox Accounts Profile Server host
    *   @param {Object} [options.window]
    *   window override, used for unit tests
    *   @param {Object} [options.lightbox]
@@ -59,100 +32,9 @@ define([
       throw new Error('clientId is required');
     }
 
-    this.auth = {
-      /**
-       * Sign in an existing user.
-       *
-       * @method signIn
-       * @param {Object} config - configuration
-       *   @param {String} config.state
-       *   CSRF/State token
-       *   @param {String} config.redirect_uri
-       *   URI to redirect to when complete
-       *   @param {String} config.scope
-       *   OAuth scope
-       *   @param {String} [config.email]
-       *   Email address used to pre-fill into the account form,
-       *   but the user is free to change it. Set to the string literal
-       *   `blank` to ignore any previously signed in email. Default is
-       *   the last email address used to sign in.
-       *   @param {String} [config.ui]
-       *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
-       */
-      signIn: function (config) {
-        var self = this;
-        return p().then(function () {
-          config = config || {};
-
-          var api = getUI(self, config.ui, clientId, options);
-          return api.signIn(config)
-            .fin(function () {
-              delete self._ui;
-            });
-        });
-      },
-
-      /**
-       * Force a user to sign in as an existing user.
-       *
-       * @method forceAuth
-       * @param {Object} config - configuration
-       *   @param {String} config.state
-       *   CSRF/State token
-       *   @param {String} config.redirect_uri
-       *   URI to redirect to when complete
-       *   @param {String} config.scope
-       *   OAuth scope
-       *   @param {String} config.email
-       *   Email address the user must sign in with. The user
-       *   is unable to modify the email address and is unable
-       *   to sign up if the address is not registered.
-       *   @param {String} [config.ui]
-       *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
-       */
-      forceAuth: function (config) {
-        var self = this;
-        return p().then(function () {
-          config = config || {};
-
-          var api = getUI(self, config.ui, clientId, options);
-          return api.forceAuth(config)
-            .fin(function () {
-              delete self._ui;
-            });
-        });
-      },
-
-      /**
-       * Sign up a new user
-       *
-       * @method signUp
-       * @param {Object} config - configuration
-       *   @param {String} config.state
-       *   CSRF/State token
-       *   @param {String} config.redirect_uri
-       *   URI to redirect to when complete
-       *   @param {String} config.scope
-       *   OAuth scope
-       *   @param {String} [config.email]
-       *   Email address used to pre-fill into the account form,
-       *   but the user is free to change it.
-       *   @param {String} [config.ui]
-       *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
-       */
-      signUp: function (config) {
-        var self = this;
-        return p().then(function () {
-          config = config || {};
-
-          var api = getUI(self, config.ui, clientId, options);
-          return api.signUp(config)
-            .fin(function () {
-              delete self._ui;
-            });
-        });
-      }
-    };
+    this.auth = new AuthAPI(clientId, options);
+    this.token = new TokenAPI(clientId, options);
+    this.profile = new ProfileAPI(clientId, options);
   }
 
   FxaRelierClient.prototype = {

--- a/client/auth/base/api.js
+++ b/client/auth/base/api.js
@@ -2,66 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*globals define*/
+
 define([
   'p-promise',
+  'client/lib/constants',
+  'client/lib/options',
   'client/lib/function',
-  'client/auth/lightbox/api',
-  'client/auth/redirect/api'
-], function (p, FunctionHelpers, LightboxUI, RedirectUI) {
+  'client/lib/url'
+], function (p, Constants, Options, FunctionHelpers, Url) {
   'use strict';
 
   var partial = FunctionHelpers.partial;
 
-  var UIs = {
-    'default': RedirectUI,
-    lightbox: LightboxUI,
-    redirect: RedirectUI
-  };
-
-  function getUI(context, ui, clientId, options) {
-    if (context._ui) {
-      throw new Error('Firefox Accounts is already open');
-    }
-
-    if (typeof ui === 'object') {
-      // allow a UI to be passed in for testing.
-      context._ui = ui;
-    } else {
-      ui = ui || 'default';
-      var UI = UIs[ui];
-
-      if (! UI) {
-        throw new Error('Invalid ui: ' + ui);
-      }
-
-      context._ui = new UI(clientId, options);
-    }
-
-    return context._ui;
-  }
-
-  function authenticate(authType, config) {
-    //jshint validthis: true
-    var self = this;
-    return p().then(function () {
-      config = config || {};
-
-      var api = getUI(self, config.ui, self._clientId, self._options);
-      return api[authType](config)
-        .fin(function () {
-          delete self._ui;
-        });
-    });
-  }
-
-
   /**
-   * @class FxaAuthAPI
+   * @class AuthenticationAPI
    * @constructor
    * @param {string} clientId - the OAuth client ID for the relier
    * @param {Object} [options={}] - configuration
-   *   @param {String} [options.contentHost]
-   *   Firefox Accounts Content Server host
    *   @param {String} [options.oauthHost]
    *   Firefox Accounts OAuth Server host
    *   @param {Object} [options.window]
@@ -71,18 +29,62 @@ define([
    *   @param {Object} [options.channel]
    *   channel override, used for unit tests
    */
-  function FxaAuthAPI(clientId, options) {
+  function AuthenticationAPI(clientId, options) {
     if (! clientId) {
       throw new Error('clientId is required');
     }
 
     this._clientId = clientId;
-    this._options = options;
+    this._oauthHost = options.oauthHost || Constants.DEFAULT_OAUTH_HOST;
+    this._window = options.window || window;
   }
 
-  FxaAuthAPI.prototype = {
+  function authenticate(action, config) {
+    //jshint validthis: true
+    var self = this;
+    config = config || {};
+    return p().then(function () {
+      var requiredOptions = ['scope', 'state', 'redirect_uri'];
+      Options.checkRequired(requiredOptions, config);
+
+      var fxaUrl = getOAuthUrl.call(self, action, config);
+      return self.openFxa(fxaUrl);
+    });
+  }
+
+  function getOAuthUrl(action, config) {
+    //jshint validthis: true
+    var queryParams = {
+      action: action,
+      client_id: this._clientId,
+      state: config.state,
+      scope: config.scope,
+      redirect_uri: config.redirect_uri
+    };
+
+    if (config.email) {
+      queryParams.email = config.email;
+    }
+
+    return this._oauthHost + '/authorization' + Url.objectToQueryString(queryParams);
+  }
+
+  AuthenticationAPI.prototype = {
     /**
-     * Sign in an existing user.
+     * Open Firefox Accounts to authenticate the user.
+     * Must be overridden to provide API specific functionality.
+     *
+     * @method openFxa
+     * @param {String} fxaUrl - URL to open for authentication
+     *
+     * @protected
+     */
+    openFxa: function (fxaUrl) {
+      throw new Error('openFxa must be overridden');
+    },
+
+    /**
+     * Sign in an existing user
      *
      * @method signIn
      * @param {Object} config - configuration
@@ -97,10 +99,8 @@ define([
      *   but the user is free to change it. Set to the string literal
      *   `blank` to ignore any previously signed in email. Default is
      *   the last email address used to sign in.
-     *   @param {String} [config.ui]
-     *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
      */
-    signIn: partial(authenticate, 'signIn'),
+    signIn: partial(authenticate, Constants.SIGNIN_ACTION),
 
     /**
      * Force a user to sign in as an existing user.
@@ -120,7 +120,16 @@ define([
      *   @param {String} [config.ui]
      *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
      */
-    forceAuth: partial(authenticate, 'forceAuth'),
+    forceAuth: function (config) {
+      var self = this;
+      return p().then(function () {
+        config = config || {};
+        var requiredOptions = ['email'];
+        Options.checkRequired(requiredOptions, config);
+
+        return authenticate.call(self, Constants.FORCE_AUTH_ACTION, config);
+      });
+    },
 
     /**
      * Sign up a new user
@@ -136,13 +145,11 @@ define([
      *   @param {String} [config.email]
      *   Email address used to pre-fill into the account form,
      *   but the user is free to change it.
-     *   @param {String} [config.ui]
-     *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
      */
-    signUp: partial(authenticate, 'signUp')
+    signUp: partial(authenticate, Constants.SIGNUP_ACTION)
   };
 
-  return FxaAuthAPI;
+  return AuthenticationAPI;
 });
 
 

--- a/client/auth/lightbox/api.js
+++ b/client/auth/lightbox/api.js
@@ -8,10 +8,12 @@ define([
   'p-promise',
   'client/lib/object',
   'client/lib/options',
-  '../api',
+  'client/lib/constants',
+  '../base/api',
   './lightbox',
   './iframe_channel'
-], function (p, ObjectHelpers, Options, AuthenticationAPI, Lightbox, IFrameChannel) {
+], function (p, ObjectHelpers, Options, Constants, AuthenticationAPI,
+    Lightbox, IFrameChannel) {
   'use strict';
 
   function getLightbox() {
@@ -75,13 +77,27 @@ define([
    * @class LightboxAPI
    * @extends AuthenticationAPI
    * @constructor
+   * @param {string} clientId - the OAuth client ID for the relier
+   * @param {Object} [options={}] - configuration
+   *   @param {String} [options.contentHost]
+   *   Firefox Accounts Content Server host
+   *   @param {String} [options.oauthHost]
+   *   Firefox Accounts OAuth Server host
+   *   @param {Object} [options.window]
+   *   window override, used for unit tests
+   *   @param {Object} [options.lightbox]
+   *   lightbox override, used for unit tests
+   *   @param {Object} [options.channel]
+   *   channel override, used for unit tests
    */
   function LightboxAPI(clientId, options) {
+    options = options || {};
+
     AuthenticationAPI.call(this, clientId, options);
 
-    options = options || {};
     this._lightbox = options.lightbox;
     this._channel = options.channel;
+    this._contentHost = options.contentHost || Constants.DEFAULT_CONTENT_HOST;
   }
   LightboxAPI.prototype = Object.create(AuthenticationAPI.prototype);
 

--- a/client/auth/redirect/api.js
+++ b/client/auth/redirect/api.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 define([
-  '../api',
+  '../base/api',
   'client/lib/constants',
   'client/lib/options',
   'client/lib/object'

--- a/client/lib/constants.js
+++ b/client/lib/constants.js
@@ -7,7 +7,8 @@ define([], function () {
 
   return {
     DEFAULT_CONTENT_HOST: 'https://accounts.firefox.com',
-    DEFAULT_OAUTH_HOST: 'https://oauth.accounts.firefox.com/v1/authorization',
+    DEFAULT_OAUTH_HOST: 'https://oauth.accounts.firefox.com/v1',
+    DEFAULT_PROFILE_HOST: 'https://profile.accounts.firefox.com/v1',
     SIGNIN_ACTION: 'signin',
     SIGNUP_ACTION: 'signup',
     FORCE_AUTH_ACTION: 'force_auth'

--- a/client/lib/function.js
+++ b/client/lib/function.js
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+/**
+ * Simple function helpers.
+ *
+ * @module Function
+ */
+define(function () {
+  'use strict';
+
+  function partial(method/*, ...*/) {
+    var args = [].slice.call(arguments, 1);
+    return function () {
+      return method.apply(this, args.concat([].slice.call(arguments, 0)));
+    };
+  }
+
+
+  return {
+    /**
+     * Partially apply a function by filling in any number of its arguments,
+     * without changing its dynamic this value. A close cousin of
+     * Function.prototype.bind.
+     *
+     * example:
+     * function add(a, b) {
+     *   return a + b;
+     * }
+     *
+     * var add1 = partial(add, 1);
+     * var result = add1(9);
+     * // result is 10
+     *
+     * @method partial
+     * @param {Function} method
+     * method to pass arguments to.
+     * @returns {Function}
+     */
+    partial: partial
+  };
+});
+

--- a/client/lib/xhr.js
+++ b/client/lib/xhr.js
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'p-promise',
+  'components/micrajax/micrajax',
+  './function'
+], function (p, micrajax, FunctionHelpers) {
+  'use strict';
+
+  var partial = FunctionHelpers.partial;
+
+  var NodeXMLHttpRequest;
+  try {
+    // If embedded in node, use the xhr2 module
+    if (typeof require !== 'undefined') {
+      NodeXMLHttpRequest = require('xhr2');
+    }
+  } catch (e) {
+    NodeXMLHttpRequest = null;
+  }
+
+  function getXHRObject(xhr) {
+    if (xhr) {
+      return xhr;
+    } else if (NodeXMLHttpRequest) {
+      return new NodeXMLHttpRequest();
+    }
+    // fallback to the system default
+  }
+
+  /**
+   * Provides XHR functionality for use in either a browser or node
+   * environment.
+   *
+   * @module xhr
+   */
+
+  function request(method, path, data, options) {
+    options = options || {};
+
+    var deferred = p.defer();
+
+    micrajax.ajax({
+      type: method,
+      url: path,
+      data: data,
+      contentType: options.contentType || 'application/json',
+      headers: options.headers,
+      xhr: getXHRObject(options.xhr),
+      success: function (data, responseText, jqXHR) {
+        deferred.resolve(data);
+      },
+      error: function (jqXHR, status, responseText) {
+        deferred.reject(responseText);
+      }
+    });
+
+    return deferred.promise;
+  }
+
+  var XHR = {
+    /**
+     * Perform a GET request
+     * @method get
+     * @param {String} path
+     * endpoint URL
+     * @param {Object || String} [data]
+     * data to send
+     * @param {Object} [options={}]
+     * Options
+     * @param {String} [options.contentType]
+     * Content type of `data`. Defaults to `application/json`
+     * @param {Object} [options.xhr]
+     * XMLHttpRequest compatible object to use for XHR requests
+     * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+     */
+    get: partial(request, 'GET'),
+
+    /**
+     * Perform a POST request
+     * @method post
+     * @param {String} path
+     * endpoint URL
+     * @param {Object || String} [data]
+     * data to send
+     * @param {Object} [options={}]
+     * Options
+     * @param {String} [options.contentType]
+     * Content type of `data`. Defaults to `application/json`
+     * @param {Object} [options.xhr]
+     * XMLHttpRequest compatible object to use for XHR requests
+     * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+     * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+     */
+    post: partial(request, 'POST')
+  };
+
+  return XHR;
+});

--- a/client/profile/api.js
+++ b/client/profile/api.js
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'p-promise',
+  'client/lib/constants',
+  'client/lib/xhr',
+  'client/lib/object'
+], function (p, Constants, Xhr, ObjectHelpers) {
+  'use strict';
+
+  /**
+   * @class ProfileAPI
+   * @constructor
+   * @param {string} clientId - the OAuth client ID for the relier
+   * @param {Object} [options={}] - configuration
+   *   @param {String} [options.profileHost]
+   *   Firefox Accounts Profile Server host
+   */
+  function ProfileAPI(clientId, options) {
+    if (! clientId) {
+      throw new Error('clientId is required');
+    }
+    this._clientId = clientId;
+
+    options = options || {};
+    this._profileHost = options.profileHost || Constants.DEFAULT_PROFILE_HOST;
+  }
+
+  ProfileAPI.prototype = {
+    /**
+     * Fetch a user's profile data.
+     *
+     * @method fetch
+     * @param {String} token
+     * Scoped OAuth token that can be used to access the profile data
+     * @param {Object} [options={}] - configuration
+     *   @param {String} [options.xhr]
+     *   XMLHttpRequest compatible object to use to make the request.
+     * @returns {Promise}
+     * Response resolves to the user's profile data on success.
+     */
+    fetch: function (token, options) {
+      if (! token) {
+        throw new Error('token is required');
+      }
+
+      var xhrOptions = ObjectHelpers.extend({
+        headers: {
+          Authorization: 'Bearer ' + token
+        }
+      }, options);
+
+      var self = this;
+      return Xhr.get(self._profileHost + '/profile', {}, xhrOptions)
+        .then(function (profileData) {
+          self._profileData = profileData;
+          return profileData;
+        });
+    },
+
+    /**
+     * Get all the user's profile data. Must be called after `fetch`
+     *
+     * @method all
+     * @returns {Object}
+     * User's profile data that was fetched using `fetch`.
+     */
+    all: function () {
+      return this._profileData;
+    }
+  };
+
+  return ProfileAPI;
+});
+
+

--- a/client/token/api.js
+++ b/client/token/api.js
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'p-promise',
+  'client/lib/constants',
+  'client/lib/xhr'
+], function (p, Constants, Xhr) {
+  'use strict';
+
+  /**
+   * @class TokenAPI
+   * @constructor
+   * @param {string} clientId - the OAuth client ID for the relier
+   * @param {Object} [options={}] - configuration
+   *   @param {String} [options.oauthHost]
+   *   Firefox Accounts OAuth Server host
+   */
+  function TokenAPI(clientId, options) {
+    if (! clientId) {
+      throw new Error('clientId is required');
+    }
+    this._clientId = clientId;
+
+    options = options || {};
+    this._oauthHost = options.oauthHost || Constants.DEFAULT_OAUTH_HOST;
+  }
+
+  TokenAPI.prototype = {
+    /**
+     * Trade an OAuth code for a longer lived OAuth token. See
+     * https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1token
+     *
+     * @method tradeCode
+     * @param {String} clientSecret
+     * Client secret
+     * @param {String} code
+     * OAuth code
+     * @returns {String}
+     * OAuth token
+     * @param {Object} [options={}] - configuration
+     *   @param {String} [options.xhr]
+     *   XMLHttpRequest compatible object to use to make the request.
+     * @returns {Promise}
+     * Response resolves to an object with `access_token`, `scope`, and
+     * `token_type`.
+     */
+    tradeCode: function (clientSecret, code, options) {
+      if (! clientSecret) {
+        return p.reject(new Error('clientSecret is required'));
+      }
+
+      if (! code) {
+        return p.reject(new Error('code is required'));
+      }
+
+      var endpoint = this._oauthHost + '/token';
+      return Xhr.post(endpoint, {
+          client_id: this._clientId,
+          client_secret: clientSecret,
+          code: code
+        }, options);
+    },
+
+    /**
+     * Verify an OAuth token is valid. See
+     * https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1verify
+     *
+     * @method verifyToken
+     * @param {String} token
+     * OAuth token to verify
+     * @param {Object} [options={}] - configuration
+     *   @param {String} [options.xhr]
+     *   XMLHttpRequest compatible object to use to make the request.
+     * @returns {Promise}
+     * Response resolves to an object with `user`, `client_id`, and
+     * `scopes`.
+     */
+    verifyToken: function (token, options) {
+      if (! token) {
+        return p.reject(new Error('token is required'));
+      }
+
+      var endpoint = this._oauthHost + '/verify';
+      return Xhr.post(endpoint, {
+          token: token
+        }, options);
+    },
+
+    /**
+     * After a client is done using a token, the responsible thing to do is to
+     * destroy the token afterwards. A client can use this route to do so.
+     * See https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1destroy
+     *
+     * @method destroyToken
+     * @param {String} clientSecret
+     * Client secret
+     * @param {String} token
+     * OAuth token to verify
+     * @param {Object} [options={}] - configuration
+     *   @param {String} [options.xhr]
+     *   XMLHttpRequest compatible object to use to make the request.
+     * @returns {Promise}
+     * Response resolves to an empty object.
+     */
+    destroyToken: function (clientSecret, token, options) {
+      if (! clientSecret) {
+        return p.reject(new Error('clientSecret is required'));
+      }
+
+      if (! token) {
+        return p.reject(new Error('token is required'));
+      }
+
+      var endpoint = this._oauthHost + '/destroy';
+      return Xhr.post(endpoint, {
+        client_secret: clientSecret,
+        token: token
+      }, options);
+    }
+  };
+
+  return TokenAPI;
+});
+
+

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "grunt-open": "0.2.3",
     "intern-geezer": "1.7.0",
     "load-grunt-tasks": "1.0.0"
+  },
+  "dependencies": {
+    "xhr2": "0.1.0"
   }
 }

--- a/tasks/require.js
+++ b/tasks/require.js
@@ -7,7 +7,7 @@ module.exports = function (grunt) {
 
   grunt.config('requirejs', {
     options: {
-      baseUrl: '.',
+      baseUrl: './',
       include: ['client/FxaRelierClient'],
       name: 'components/almond/almond',
       wrap: {
@@ -15,7 +15,8 @@ module.exports = function (grunt) {
         endFile: 'config/end.frag'
       },
       paths: {
-        'p-promise': 'components/p-promise/p'
+        'p-promise': 'components/p-promise/p',
+        'micrajax': 'components/micrajax/micrajax'
       }
     },
     prod: {

--- a/tests/addons/responder.js
+++ b/tests/addons/responder.js
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A responder that will respond to XHR requests. The usage is similar
+ * to sinon's useFakeXMLHttpRequest functionality. Responses automatically
+ * kick off 50ms after the last request is opened.
+ *
+ * To use, create a responder. Register some responses. Profit.
+ *
+ * Example:
+ *
+ * var responder = new Responder();
+ * responder.respondWith('GET', '/endpoint', { status: 404, headers:
+ *    { 'Content-Type': 'text/text', body: 'Not found' });
+ *
+ * If `status` is not specified, a default of `200` is used.
+ * If `headers` is not specified, a default of
+ *     `{ 'Content-Type': 'application/json' }` is used.
+ */
+
+define([
+  'tests/addons/sinon'
+], function (sinon) {
+  'use strict';
+
+  function Responder(options) {
+    options = options || {};
+    this._respondAfter = options.respondAfter || 50;
+  }
+  Responder.prototype = {
+    respondWith: function (method, url, response) {
+      var self = this;
+      if (! this._isInitialized) {
+        this._isInitialized = true;
+        this._requests = [];
+        this._responses = {};
+
+        var mockXMLHttpRequest = sinon.useFakeXMLHttpRequest();
+        mockXMLHttpRequest.onCreate = function (_request) {
+          self._requests.push(_request);
+        };
+
+        this._mockXMLHttpRequest = mockXMLHttpRequest;
+      }
+
+      var namespace = method + ': ' + url;
+      this._responses[namespace] = response;
+
+      var mockXhrRequest = new this._mockXMLHttpRequest();
+
+      var origOpen = mockXhrRequest.open;
+      mockXhrRequest.open = function () {
+        if (self._flushTimeout) {
+          // clear any old flush timers, only one flush should be kicked off.
+          clearTimeout(self._flushTimeout);
+        }
+
+        // get the party started. The responses will be flushed
+        // `this._respondAfter` ms after the last request is opened.
+        self._flushTimeout = setTimeout(self._flushResponses.bind(self), self._respondAfter);
+
+        // `this` here is valid, call the original open in the context
+        // of the mockXhrRequest.
+        return origOpen.apply(this, arguments);
+      };
+
+      return mockXhrRequest;
+    },
+
+    _flushResponses: function () {
+      var self = this;
+      var requests = self._requests;
+      // set up to respond to any new requests that come in.
+      self._requests = [];
+      requests.forEach(function (request) {
+        var namespace = request.method + ': ' + request.url;
+        var response = self._responses[namespace];
+        if (! response) {
+          throw new Error('No response for ' + namespace);
+        }
+        var status = response.status || 200;
+        var headers = response.headers || {
+          'Content-Type': 'application/json'
+        };
+        request.respond(status, headers, response.body);
+      });
+    },
+
+    restore: function () {
+      if (this._isInitialized) {
+        delete this._isInitialized;
+        this._mockXMLHttpRequest.restore();
+      }
+    }
+  };
+
+  return Responder;
+
+});

--- a/tests/spec/FxaRelierClient.js
+++ b/tests/spec/FxaRelierClient.js
@@ -3,15 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /*global define*/
+
 define([
   'intern!bdd',
   'intern/chai!assert',
   'tests/addons/sinon',
   'client/FxaRelierClient',
-  'client/auth/lightbox/api',
   'tests/mocks/window',
   'p-promise'
-], function (bdd, assert, sinon, FxaRelierClient, LightboxUI, WindowMock, p) {
+], function (bdd, assert, sinon, FxaRelierClient, WindowMock, p) {
   'use strict';
 
   bdd.describe('FxaRelierClient', function () {
@@ -33,205 +33,9 @@ define([
           window: new WindowMock()
         });
 
-        assert.isFunction(client.auth.signIn);
-        assert.isFunction(client.auth.signUp);
-      });
-    });
-
-    bdd.describe('signIn', function () {
-      var config;
-      var ui;
-      var windowMock;
-
-      bdd.beforeEach(function () {
-        windowMock = new WindowMock();
-        ui = new LightboxUI('client_id', {
-          window: windowMock
-        });
-        config = {
-          ui: ui,
-          state: 'state',
-          redirect_uri: 'http://redirect.to.me',
-          scope: 'profiles'
-        };
-      });
-
-      bdd.it('creates and loads a UI', function () {
-        var client = new FxaRelierClient('client_id', {
-          window: new WindowMock()
-        });
-
-        sinon.stub(ui, 'signIn', function () {
-          return p();
-        });
-
-        return client.auth.signIn(config);
-      });
-
-      bdd.it('throws when re-opening FxA if already open', function () {
-        var client = new FxaRelierClient('client_id', {
-          window: new WindowMock()
-        });
-
-        sinon.stub(ui, 'signIn', function () {
-          // prevent the first window from completing
-          return p.defer().promise;
-        });
-
-        client.auth.signIn(config);
-        return client.auth.signIn(config)
-          .then(assert.fail, function (err) {
-            assert.equal(err.message, 'Firefox Accounts is already open');
-          });
-      });
-
-      bdd.it('does not throw if re-opening FxA after first transaction completes', function () {
-        var client = new FxaRelierClient('client_id', {
-          window: new WindowMock()
-        });
-
-        sinon.stub(ui, 'signIn', function () {
-          return p();
-        });
-
-        return client.auth.signIn(config)
-          .then(function () {
-            return client.auth.signIn(config);
-          });
-      });
-    });
-
-    bdd.describe('forceAuth', function () {
-      var configWithoutEmail;
-      var configWithEmail;
-      var ui;
-      var windowMock;
-
-      bdd.beforeEach(function () {
-        windowMock = new WindowMock();
-        ui = new LightboxUI('client_id', {
-          window: windowMock
-        });
-        configWithoutEmail = {
-          ui: ui,
-          state: 'state',
-          redirect_uri: 'http://redirect.to.me',
-          scope: 'profiles'
-        };
-        configWithEmail = {
-          ui: ui,
-          state: 'state',
-          redirect_uri: 'http://redirect.to.me',
-          scope: 'profiles',
-          email: 'testuser@testuser.com'
-        };
-      });
-
-      bdd.it('creates and loads a UI', function () {
-        var client = new FxaRelierClient('client_id', {
-          window: new WindowMock()
-        });
-
-        sinon.stub(ui, 'forceAuth', function () {
-          return p();
-        });
-
-        return client.auth.forceAuth(configWithEmail);
-      });
-
-      bdd.it('throws when re-opening FxA if already open', function () {
-        var client = new FxaRelierClient('client_id', {
-          window: new WindowMock()
-        });
-
-        sinon.stub(ui, 'forceAuth', function () {
-          // prevent the first window from completing
-          return p.defer().promise;
-        });
-
-        client.auth.forceAuth(configWithEmail);
-        return client.auth.forceAuth(configWithEmail)
-          .then(assert.fail, function (err) {
-            assert.equal(err.message, 'Firefox Accounts is already open');
-          });
-      });
-
-      bdd.it('does not throw if re-opening FxA after first transaction completes', function () {
-        var client = new FxaRelierClient('client_id', {
-          window: new WindowMock()
-        });
-
-        sinon.stub(ui, 'forceAuth', function () {
-          return p();
-        });
-
-        return client.auth.forceAuth(configWithEmail)
-          .then(function () {
-            return client.auth.forceAuth(configWithEmail);
-          });
-      });
-    });
-
-    bdd.describe('signUp', function () {
-      var config;
-      var ui;
-      var windowMock;
-
-      bdd.beforeEach(function () {
-        windowMock = new WindowMock();
-        ui = new LightboxUI('client_id', {
-          window: windowMock
-        });
-        config = {
-          ui: ui,
-          state: 'state',
-          redirect_uri: 'http://redirect.to.me',
-          scope: 'profiles'
-        };
-      });
-
-      bdd.it('creates and loads a UI', function () {
-        var client = new FxaRelierClient('client_id', {
-          window: new WindowMock()
-        });
-
-        sinon.stub(ui, 'signUp', function () {
-          return p();
-        });
-
-        return client.auth.signUp(config);
-      });
-
-      bdd.it('throws when re-opening FxA if already open', function () {
-        var client = new FxaRelierClient('client_id', {
-          window: new WindowMock()
-        });
-
-        sinon.stub(ui, 'signUp', function () {
-          // prevent the first window from completing
-          return p.defer().promise;
-        });
-
-        client.auth.signUp(config);
-        return client.auth.signUp(config)
-          .then(assert.fail, function (err) {
-            assert.equal(err.message, 'Firefox Accounts is already open');
-          });
-      });
-
-      bdd.it('does not throw if re-opening FxA after first transaction completes', function () {
-        var client = new FxaRelierClient('client_id', {
-          window: new WindowMock()
-        });
-
-        sinon.stub(ui, 'signUp', function () {
-          return p();
-        });
-
-        return client.auth.signUp(config)
-          .then(function () {
-            return client.auth.signUp(config);
-          });
+        assert.isDefined(client.auth);
+        assert.isDefined(client.profile);
+        assert.isDefined(client.token);
       });
     });
   });

--- a/tests/spec/auth/api.js
+++ b/tests/spec/auth/api.js
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*global define*/
+
+define([
+  'intern!bdd',
+  'intern/chai!assert',
+  'tests/addons/sinon',
+  'client/FxaRelierClient',
+  'client/auth/lightbox/api',
+  'tests/mocks/window',
+  'p-promise'
+], function (bdd, assert, sinon, FxaRelierClient, LightboxUI, WindowMock, p) {
+  'use strict';
+
+  bdd.describe('AuthAPI', function () {
+    bdd.describe('signIn', function () {
+      var config;
+      var ui;
+      var windowMock;
+      var client;
+
+      bdd.beforeEach(function () {
+        windowMock = new WindowMock();
+        ui = new LightboxUI('client_id', {
+          window: windowMock
+        });
+        config = {
+          ui: ui,
+          state: 'state',
+          redirect_uri: 'http://redirect.to.me',
+          scope: 'profiles'
+        };
+        client = new FxaRelierClient('client_id', {
+          window: windowMock
+        });
+      });
+
+      bdd.it('creates and loads a UI', function () {
+        sinon.stub(ui, 'signIn', function () {
+          return p();
+        });
+
+        return client.auth.signIn(config);
+      });
+
+      bdd.it('throws when re-opening FxA if already open', function () {
+        var client = new FxaRelierClient('client_id', {
+          window: new WindowMock()
+        });
+
+        sinon.stub(ui, 'signIn', function () {
+          // prevent the first window from completing
+          return p.defer().promise;
+        });
+
+        client.auth.signIn(config);
+        return client.auth.signIn(config)
+          .then(assert.fail, function (err) {
+            assert.equal(err.message, 'Firefox Accounts is already open');
+          });
+      });
+
+      bdd.it('does not throw if re-opening FxA after first transaction completes', function () {
+        sinon.stub(ui, 'signIn', function () {
+          return p();
+        });
+
+        return client.auth.signIn(config)
+          .then(function () {
+            return client.auth.signIn(config);
+          });
+      });
+    });
+
+    bdd.describe('forceAuth', function () {
+      var configWithoutEmail;
+      var configWithEmail;
+      var ui;
+      var windowMock;
+      var client;
+
+      bdd.beforeEach(function () {
+        windowMock = new WindowMock();
+        ui = new LightboxUI('client_id', {
+          window: windowMock
+        });
+        configWithoutEmail = {
+          ui: ui,
+          state: 'state',
+          redirect_uri: 'http://redirect.to.me',
+          scope: 'profiles'
+        };
+        configWithEmail = {
+          ui: ui,
+          state: 'state',
+          redirect_uri: 'http://redirect.to.me',
+          scope: 'profiles',
+          email: 'testuser@testuser.com'
+        };
+        client = new FxaRelierClient('client_id', {
+          window: windowMock
+        });
+      });
+
+      bdd.it('creates and loads a UI', function () {
+        sinon.stub(ui, 'forceAuth', function () {
+          return p();
+        });
+
+        return client.auth.forceAuth(configWithEmail);
+      });
+
+      bdd.it('throws when re-opening FxA if already open', function () {
+        sinon.stub(ui, 'forceAuth', function () {
+          // prevent the first window from completing
+          return p.defer().promise;
+        });
+
+        client.auth.forceAuth(configWithEmail);
+        return client.auth.forceAuth(configWithEmail)
+          .then(assert.fail, function (err) {
+            assert.equal(err.message, 'Firefox Accounts is already open');
+          });
+      });
+
+      bdd.it('does not throw if re-opening FxA after first transaction completes', function () {
+        sinon.stub(ui, 'forceAuth', function () {
+          return p();
+        });
+
+        return client.auth.forceAuth(configWithEmail)
+          .then(function () {
+            return client.auth.forceAuth(configWithEmail);
+          });
+      });
+    });
+
+    bdd.describe('signUp', function () {
+      var config;
+      var ui;
+      var windowMock;
+      var client;
+
+      bdd.beforeEach(function () {
+        windowMock = new WindowMock();
+        ui = new LightboxUI('client_id', {
+          window: windowMock
+        });
+        config = {
+          ui: ui,
+          state: 'state',
+          redirect_uri: 'http://redirect.to.me',
+          scope: 'profiles'
+        };
+
+        client = new FxaRelierClient('client_id', {
+          window: windowMock
+        });
+      });
+
+      bdd.it('creates and loads a UI', function () {
+        sinon.stub(ui, 'signUp', function () {
+          return p();
+        });
+
+        return client.auth.signUp(config);
+      });
+
+      bdd.it('throws when re-opening FxA if already open', function () {
+        sinon.stub(ui, 'signUp', function () {
+          // prevent the first window from completing
+          return p.defer().promise;
+        });
+
+        client.auth.signUp(config);
+        return client.auth.signUp(config)
+          .then(assert.fail, function (err) {
+            assert.equal(err.message, 'Firefox Accounts is already open');
+          });
+      });
+
+      bdd.it('does not throw if re-opening FxA after first transaction completes', function () {
+        sinon.stub(ui, 'signUp', function () {
+          return p();
+        });
+
+        return client.auth.signUp(config)
+          .then(function () {
+            return client.auth.signUp(config);
+          });
+      });
+    });
+  });
+});
+
+

--- a/tests/spec/lib/xhr.js
+++ b/tests/spec/lib/xhr.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!bdd',
+  'intern/chai!assert',
+  'tests/addons/sinon',
+  'client/lib/xhr'
+], function (bdd, assert, sinon, xhr) {
+  'use strict';
+
+  bdd.describe('xhr', function () {
+    var mockXMLHttpRequest;
+    var mockXHR;
+    var serverRequest;
+
+    bdd.beforeEach(function () {
+      mockXMLHttpRequest = sinon.useFakeXMLHttpRequest();
+      mockXMLHttpRequest.onCreate = function (_request) {
+        serverRequest = _request;
+      };
+      mockXHR = new mockXMLHttpRequest();
+    });
+
+    bdd.afterEach(function () {
+      mockXMLHttpRequest.restore();
+    });
+
+    bdd.describe('get', function () {
+      bdd.it('should perform a GET request', function () {
+        var dfd = this.async(1000);
+
+        var requestData = { key: 'value' };
+        xhr.get('/get_request', requestData, {
+          xhr: mockXHR
+        })
+        .then(dfd.callback(function (resp) {
+          assert.equal(serverRequest.method, 'GET');
+          assert.equal(serverRequest.url, '/get_request?key=value');
+          assert.isTrue(resp.success);
+        }), dfd.reject.bind(dfd));
+
+        serverRequest.respond(200, {
+          'Content-Type': 'application/json'
+        }, JSON.stringify({ success: true }));
+      });
+    });
+
+    bdd.describe('post', function () {
+      bdd.it('should perform a POST request', function () {
+        var dfd = this.async(1000);
+
+        var requestData = { key: 'value' };
+        xhr.post('/post_request', requestData, {
+          xhr: mockXHR
+        })
+        .then(dfd.callback(function (resp) {
+          assert.equal(serverRequest.method, 'POST');
+          assert.equal(serverRequest.url, '/post_request')
+          assert.equal(serverRequest.requestBody, JSON.stringify(requestData));
+          assert.isTrue(resp.success);
+        }), dfd.reject.bind(dfd));
+
+        serverRequest.respond(200, {
+          'Content-Type': 'application/json'
+        }, JSON.stringify({ success: true }));
+      });
+    });
+  });
+});

--- a/tests/spec/profile/api.js
+++ b/tests/spec/profile/api.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!bdd',
+  'intern/chai!assert',
+  'tests/addons/responder',
+  'client/profile/api',
+  'client/lib/constants',
+], function (bdd, assert, Responder, ProfileAPI, Constants) {
+  'use strict';
+
+  bdd.describe('ProfileAPI', function () {
+    var api;
+    var responder;
+
+    bdd.beforeEach(function () {
+      api = new ProfileAPI('client_id', {});
+      responder = new Responder();
+    });
+
+    bdd.afterEach(function () {
+      responder.restore();
+    });
+
+    bdd.describe('fetch', function () {
+      bdd.it('sends token to server in `Bearer` header', function () {
+        var email = 'testuser1@testuser.com';
+
+        var endpoint = Constants.DEFAULT_PROFILE_HOST + '/profile';
+        var mockXHR = responder.respondWith('GET', endpoint, {
+          body: JSON.stringify({
+            email: email
+          })
+        });
+
+        return api.fetch('token', { xhr: mockXHR })
+          .then(function (profile) {
+
+            assert.equal(
+                mockXHR.requestHeaders.Authorization, 'Bearer token');
+
+            assert.equal(profile.email, email);
+          });
+      });
+    });
+
+    bdd.describe('all', function () {
+      bdd.it('retrieves all properties of a profile', function () {
+        var email = 'testuser1@testuser.com';
+
+        var endpoint = Constants.DEFAULT_PROFILE_HOST + '/profile';
+        var mockXHR = responder.respondWith('GET', endpoint, {
+          body: JSON.stringify({
+            email: email
+          })
+        });
+
+        return api.fetch('token', { xhr: mockXHR })
+          .then(function () {
+            return api.all();
+          })
+          .then(function (profile) {
+            assert.equal(profile.email, email);
+          });
+      });
+    });
+  });
+});
+

--- a/tests/spec/token/api.js
+++ b/tests/spec/token/api.js
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!bdd',
+  'intern/chai!assert',
+  'tests/addons/responder',
+  'client/token/api',
+  'client/lib/constants'
+], function (bdd, assert, Responder, TokenAPI, Constants) {
+  'use strict';
+
+  bdd.describe('TokenAPI', function () {
+    var api;
+    var responder;
+
+    bdd.beforeEach(function () {
+      api = new TokenAPI('client_id', {});
+      responder = new Responder();
+    });
+
+    bdd.afterEach(function () {
+      responder.restore();
+    });
+
+    bdd.describe('tradeCode', function () {
+      bdd.it('trades a valid OAuth code for an OAuth token', function () {
+        var endpoint = Constants.DEFAULT_OAUTH_HOST + '/token';
+        var mockXHR = responder.respondWith('POST', endpoint, {
+          body: JSON.stringify({
+            access_token: 'token',
+            scope: 'scope',
+            token_type: 'bearer'
+          })
+        });
+
+        return api.tradeCode('secret', 'code', {
+          xhr: mockXHR
+        })
+        .then(function (resp) {
+          assert.equal(resp.access_token, 'token');
+          assert.equal(resp.scope, 'scope');
+          assert.equal(resp.token_type, 'bearer');
+
+          var reqBody = JSON.parse(mockXHR.requestBody);
+          assert.equal(reqBody.client_id, 'client_id');
+          assert.equal(reqBody.client_secret, 'secret');
+          assert.equal(reqBody.code, 'code');
+        });
+      });
+    });
+
+    bdd.describe('verifyToken', function () {
+      bdd.it('resolves with token info if token is valid', function () {
+        var endpoint = Constants.DEFAULT_OAUTH_HOST + '/verify';
+        var mockXHR = responder.respondWith('POST', endpoint, {
+          body: JSON.stringify({
+            user: 'uid',
+            client_id: 'client_id',
+            scopes: ['profile:email', 'profile:avatar']
+          })
+        });
+
+        return api.verifyToken('token', {
+          xhr: mockXHR
+        })
+        .then(function (resp) {
+          assert.equal(resp.user, 'uid');
+          assert.equal(resp.client_id, 'client_id');
+          assert.equal(resp.scopes[0], 'profile:email');
+          assert.equal(resp.scopes[1], 'profile:avatar');
+
+          var reqBody = JSON.parse(mockXHR.requestBody);
+          assert.equal(reqBody.token, 'token');
+        });
+      });
+    });
+
+    bdd.describe('destroyToken', function () {
+      bdd.it('resolves with empty object if token is valid', function () {
+        var endpoint = Constants.DEFAULT_OAUTH_HOST + '/destroy';
+
+        var mockXHR = responder.respondWith('POST', endpoint, {
+          body: JSON.stringify({})
+        });
+
+        return api.destroyToken('secret', 'token', {
+          xhr: mockXHR
+        })
+        .then(function (resp) {
+          assert.ok(resp);
+
+          var reqBody = JSON.parse(mockXHR.requestBody);
+          assert.equal(reqBody.client_secret, 'secret');
+          assert.equal(reqBody.token, 'token');
+        });
+      });
+    });
+  });
+});
+

--- a/tests/test_list.js
+++ b/tests/test_list.js
@@ -4,8 +4,12 @@
 
 define([
   './spec/FxaRelierClient',
+  './spec/auth/api',
   './spec/auth/redirect/api',
   './spec/auth/lightbox/api',
   './spec/auth/lightbox/iframe_channel',
-  './spec/auth/lightbox/lightbox'
+  './spec/auth/lightbox/lightbox',
+  './spec/token/api',
+  './spec/profile/api',
+  './spec/lib/xhr'
 ], function () {});


### PR DESCRIPTION
See https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md

* Move the `auth` namespace from FxaRelierClient.js to client/auth/api.js
* The XHR module uses micrajax to do the actual XHR requests. In theory this should also be compatible with node using the xhr2 module. I have not yet tested this.
* Add a responder addon that makes setting up sinon responses super simple.
* Remove the comment about `force_email`

fixes #16