### PR TITLE
feat: Reliers can set the lightbox background and zIndex.

### DIFF
--- a/client/auth/api.js
+++ b/client/auth/api.js
@@ -99,6 +99,12 @@ define([
      *   the last email address used to sign in.
      *   @param {String} [config.ui]
      *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
+     *   @param {Number} [options.zIndex]
+     *   only used when `config.ui=lightbox`. The zIndex of the lightbox background.
+     *   @default 100
+     *   @param {String} [options.background]
+     *   only used when `config.ui=lightbox`. The `background` CSS value
+     *   @default rgba(0,0,0,0.5)
      */
     signIn: partial(authenticate, 'signIn'),
 
@@ -119,6 +125,12 @@ define([
      *   to sign up if the address is not registered.
      *   @param {String} [config.ui]
      *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
+     *   @param {Number} [options.zIndex]
+     *   only used when `config.ui=lightbox`. The zIndex of the lightbox background.
+     *   @default 100
+     *   @param {String} [options.background]
+     *   only used when `config.ui=lightbox`. The `background` CSS value
+     *   @default rgba(0,0,0,0.5)
      */
     forceAuth: partial(authenticate, 'forceAuth'),
 
@@ -138,6 +150,12 @@ define([
      *   but the user is free to change it.
      *   @param {String} [config.ui]
      *   UI to present - `lightbox` or `redirect` - defaults to `redirect`
+     *   @param {Number} [options.zIndex]
+     *   only used when `config.ui=lightbox`. The zIndex of the lightbox background.
+     *   @default 100
+     *   @param {String} [options.background]
+     *   only used when `config.ui=lightbox`. The `background` CSS value
+     *   @default rgba(0,0,0,0.5)
      */
     signUp: partial(authenticate, 'signUp')
   };

--- a/client/auth/base/api.js
+++ b/client/auth/base/api.js
@@ -51,7 +51,7 @@ define([
       Options.checkRequired(requiredOptions, config);
 
       var fxaUrl = getOAuthUrl.call(self, action, config);
-      return self.openFxa(fxaUrl);
+      return self.openFxa(fxaUrl, config);
     });
   }
 
@@ -79,10 +79,11 @@ define([
      *
      * @method openFxa
      * @param {String} fxaUrl - URL to open for authentication
+     * @param {options={}} options
      *
      * @protected
      */
-    openFxa: function (fxaUrl) {
+    openFxa: function (fxaUrl, options) {
       throw new Error('openFxa must be overridden');
     },
 

--- a/client/auth/lightbox/api.js
+++ b/client/auth/lightbox/api.js
@@ -30,7 +30,7 @@ define([
     return self._lightbox;
   }
 
-  function openLightbox(fxaUrl) {
+  function openLightbox(fxaUrl, options) {
     /*jshint validthis: true*/
     var self = this;
     return p().then(function() {
@@ -40,7 +40,7 @@ define([
 
       var lightbox = getLightbox.call(self);
 
-      lightbox.load(fxaUrl);
+      lightbox.load(fxaUrl, options);
 
       return lightbox;
     });
@@ -102,11 +102,11 @@ define([
   LightboxBroker.prototype = Object.create(BaseBroker.prototype);
 
   ObjectHelpers.extend(LightboxBroker.prototype, {
-    openFxa: function (fxaUrl) {
+    openFxa: function (fxaUrl, options) {
       /*jshint validthis: true*/
       var self = this;
 
-      return openLightbox.call(self, fxaUrl)
+      return openLightbox.call(self, fxaUrl, options)
         .then(function (lightbox) {
           return waitForAuthentication.call(self, lightbox);
         })

--- a/client/auth/lightbox/lightbox.js
+++ b/client/auth/lightbox/lightbox.js
@@ -4,11 +4,6 @@
 
 /*globals define*/
 
-/**
- * Create a lightbox.
- *
- * @class Lightbox
- */
 define([
 ], function () {
   'use strict';
@@ -34,6 +29,15 @@ define([
   }
 
 
+  /**
+   * Create a lightbox.
+   *
+   * @class Lightbox
+   * @constructor
+   * @param {options={}} options
+   * @param {String} options.window
+   * The window object
+   */
   function Lightbox(options) {
     options = options || {};
 
@@ -46,16 +50,30 @@ define([
      * @method load
      * @param {String} src
      * URL to load.
+     * @param {options={}} options
+     * @param {Number} [options.zIndex]
+     * z-index to set on the background.
+     * @default 100
+     * @param {String} [options.background]
+     * Lightbox background CSS.
+     * @default rgba(0,0,0,0.5)
      */
-    load: function (src) {
+    load: function (src, options) {
+      options = options || {};
+
+      var backgroundStyle = options.background || 'rgba(0,0,0,0.5)';
+      var zIndexStyle = options.zIndex || 100;
+
       var background = this._backgroundEl = createElement(this._window, 'div', {
+        id: 'fxa-background',
         style: cssPropsToString({
-          background: 'rgba(0,0,0,0.5)',
+          background: backgroundStyle,
           bottom: 0,
           left: 0,
           position: 'fixed',
           right: 0,
-          top: 0
+          top: 0,
+          'z-index': zIndexStyle
         })
       });
 

--- a/tests/spec/auth/lightbox/api.js
+++ b/tests/spec/auth/lightbox/api.js
@@ -148,6 +148,26 @@ function (bdd, assert, LightboxBroker, Lightbox, IframeChannel,
           assert.equal(err.message, 'oauth_error');
         });
       });
+
+      bdd.it('should pass along `zIndex` and `background`', function () {
+        sinon.spy(lightbox, 'load');
+        sinon.stub(channel, 'attach', function () {
+          return p();
+        });
+
+        return lightboxAPI.signIn({
+          state: 'state',
+          scope: 'scope',
+          redirectUri: 'redirectUri',
+          zIndex: 200,
+          background: '#000'
+        })
+        .then(function () {
+          var options = lightbox.load.args[0][1];
+          assert.equal(options.zIndex, 200);
+          assert.equal(options.background, "#000");
+        });
+      });
     });
 
     bdd.describe('forceAuth', function () {

--- a/tests/spec/auth/lightbox/lightbox.js
+++ b/tests/spec/auth/lightbox/lightbox.js
@@ -42,12 +42,33 @@ define([
         lightbox.load(CONTENT_URL);
 
         assert.equal(child.type, 'div');
+        // ensure some default styles are set
+        var style = child.getAttribute('style');
+        assert.include(style, 'z-index:100');
+        assert.include(style, 'background:rgba(0,0,0,0.5)');
 
         var src = lightbox.getContentElement().getAttribute('src');
         assert.equal(src, CONTENT_URL);
 
         var contentWindow = lightbox.getContentWindow();
         assert.isTrue(contentWindow instanceof WindowMock);
+      });
+
+      bdd.it('relier can set `zIndex` and `background`', function () {
+        var child;
+        windowMock.document.body.appendChild = function (_child) {
+          child = _child;
+        };
+
+        lightbox.load(CONTENT_URL, {
+          zIndex: 150,
+          background: '#000'
+        });
+
+        // ensure some overridden styles are set
+        var style = child.getAttribute('style');
+        assert.include(style, 'z-index:150');
+        assert.include(style, 'background:#000')
       });
     });
   });


### PR DESCRIPTION
Example usage:
```js
var relierClient = new FxaRelierClient(<client_id>);
relierClient.auth.signIn({
  state: <state>,
  scope: 'profile',
  redirectUri: <redirect_uri>,
  ui: 'lightbox',
  zIndex: 20000,
  background: '#000'
})
```

fixes #38
fixes #39