### PR TITLE
fix(node): Fix the amd-loader when loading es6-promise

### DIFF
--- a/node/amd-loader.js
+++ b/node/amd-loader.js
@@ -19,7 +19,12 @@ module.exports = function amdload(absoluteFilename, baseUrl, map) {
   var amdrequire = function amdrequire(filepath) {
     // Return real node modules if we have them mapped
     if (filepath in map) {
-      return require(map[filepath]);
+      // es6-promise tries to export using define from requirejs,
+      // ditch global.define while calling `require`, then put it back.
+      delete global.define;
+      var source = require(map[filepath]);
+      global.define = oldDefine;
+      return source;
     }
 
     // by default, cwd is the baseUrl unless the filepath


### PR DESCRIPTION
es6-promise saw that `global.define` was defined and tried
to export itself using AMD instead of the expected CommonJS
format.

While loading CommonJS modules, remove `global.define` so modules
do not attempt to export using AMD, then add global.define back when
complete.

@vladikoff - Adds on to your PR.